### PR TITLE
Add generic equipment support for rack drawings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,60 +1,46 @@
-## Workflow Orchestration
+## Workflow
 
-### 1. Plan Mode Default
-
-- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
-- If something goes sideways, STOP and re-plan immediately - don't keep pushing
-- Use plan mode for verification steps, not just building
-- Write detailed specs upfront to reduce ambiguity
-
-### 2. Subagent Strategy
-
-- Use subagents liberally to keep main context window clean
-- Offload research, exploration, and parallel analysis to subagents
-- For complex problems, throw more compute at it via subagents
-- One task per subagent for focused execution
-
-### 3. Self-Improvement Loop
-
-- After ANY correction from the user: update tasks/lessons. md with the pattern
-- Write rules for yourself that prevent the same mistake
-- Ruthlessly iterate on these lessons until mistake rate drops
-- Review lessons at session start for relevant project
-
-### 4. Verification Before Done
-
-- Never mark a task complete without proving it works
-- Diff behavior between main and your changes when relevant
-- Ask yourself: "would a staff engineer approve this?"
-- Run tests, check logs, demonstrate correctness
-
-### 5. Demand Elegance (Balanced)
-
-- For non-trivial changes: pause and ask "is there a more elegant way?"
-- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
-- Skip this for simple, obvious fixes - don't over-engineer
-- Challenge your own work before presenting it
-
-### 6. Autonomous Bug Fixing
-
-When given a bug report: just fix it. Don't ask for hand-holding
-
-- Point at logs, errors, failing tests - then resolve them
-- Zero context switching required from the user
-- Go fix failing CI tests without being told how
+- **Plan Mode First**: Always use plan mode for non-trivial tasks (3+ steps or architectural decisions). STOP and replan if blocked.
+- **Verify Everything**: Run tests, check behavior, diff changes. Never mark tasks done without proof.
+- **Elegant Solutions**: For non-trivial changes, ask "is there a more elegant way?" before shipping.
+- **Bug Fixes**: Autonomous. Fix the root cause, run tests to verify, don't ask for hand-holding.
 
 ## Task Management
 
-1. **Plan First**: Write plan to tasks/todo.md" with checkable items
-2. **Verify Plan**: Check in before starting implementation
-3. **Track Progress**: Mark items complete as you go
-4. **Explain Changes**: High-level summary at each step
-5. **Document Results**: Add review section to tasks/todo.md
-6. **Capture Lessons**: Update tasks/lessons.md' after corrections
+1. Create a plan in `tasks/todo.md` with checkable items
+2. Verify the plan with the user before implementing
+3. Mark progress as you complete items
+4. Update `tasks/lessons.md` if you make mistakes
 
-## Core Principles
+## Learning Goals
 
-- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
-- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
-- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.
-- **Learning**: I am a junior developer, and one of my main goals from this project is to learn. Make sure to explain new ideas and concepts and help me learn as much as I can along the way.
+I'm a junior developer. When solving problems, explain new concepts and architectural decisions. Help me understand the "why" behind code patterns.
+
+---
+
+## Input Validation Rules
+
+- **Normalize first**: `.trim()` before checking empty/whitespace
+- **Type checking**: Use `typeof x === 'string'`, `Number.isInteger()`
+- **Edge cases**: Test empty strings, whitespace-only, non-numeric IDs
+- **Response codes**: 400 for client errors, 500 for server errors
+
+## Testing Approach
+
+- Unit tests: mock Prisma, test controller logic in isolation
+- Integration tests: use actual database, test full request/response
+- Use `npm run test:watch` for development
+- Always run full test suite before committing
+
+## Database Gotchas
+
+- Use `config/prisma.ts` for all Prisma operations
+- Schema has cascade deletes—be careful with deletions
+- Frequently queried fields (`jobId`, `flexSection`) are indexed; prioritize these in filters
+- PullsheetItem has hierarchical relationships (parent-child)—watch for circular dependencies
+
+## Common Patterns
+
+- **File naming**: `<domain>Controller.ts`, `<domain>Routes.ts`, `<domain>Service.ts`
+- **Error handling**: Try-catch at controller level; return generic error messages
+- **Routing**: All endpoints prefixed with `/api`; order matters in `app.ts`

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
-    "dev": "nodemon --exec tsx src/index.ts"
+    "dev": "nodemon --exec tsx src/index.ts",
+    "db:seed": "tsx ./prisma/seed.ts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.3.0",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   schema: 'prisma/schema.prisma',
   migrations: {
     path: 'prisma/migrations',
+    seed: 'node ./prisma/seed.ts',
   },
   datasource: {
     url: env('DATABASE_URL'),

--- a/prisma/migrations/20260301033804_add_generic_equipment/migration.sql
+++ b/prisma/migrations/20260301033804_add_generic_equipment/migration.sql
@@ -1,0 +1,22 @@
+-- AlterTable
+ALTER TABLE "PullsheetItem" ADD COLUMN     "genericEquipmentId" INTEGER;
+
+-- CreateTable
+CREATE TABLE "GenericEquipment" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "displayName" VARCHAR(255),
+    "category" VARCHAR(100) NOT NULL,
+    "rackUnits" INTEGER NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GenericEquipment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PullsheetItem_genericEquipmentId_idx" ON "PullsheetItem"("genericEquipmentId");
+
+-- AddForeignKey
+ALTER TABLE "PullsheetItem" ADD CONSTRAINT "PullsheetItem_genericEquipmentId_fkey" FOREIGN KEY ("genericEquipmentId") REFERENCES "GenericEquipment"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260301034015_add_generic_equipment_unique_name/migration.sql
+++ b/prisma/migrations/20260301034015_add_generic_equipment_unique_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `GenericEquipment` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "GenericEquipment_name_key" ON "GenericEquipment"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,10 +30,23 @@ model EquipmentCatalog {
   pullsheetItems          PullsheetItem[]
 }
 
+model GenericEquipment {
+  id             Int             @id @default(autoincrement())
+  name           String          @unique @db.VarChar(255)
+  displayName    String?         @db.VarChar(255)
+  category       String          @db.VarChar(100)
+  rackUnits      Int
+  isActive       Boolean         @default(true)
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  pullsheetItems PullsheetItem[]
+}
+
 model PullsheetItem {
   id                  Int               @id @default(autoincrement())
   jobId               Int
   equipmentCatalogId  Int?
+  genericEquipmentId  Int?
   rackDrawingId       Int?
   parentId            Int?
   name                String            @db.VarChar(500)
@@ -49,6 +62,7 @@ model PullsheetItem {
   createdAt           DateTime          @default(now())
   updatedAt           DateTime          @updatedAt
   equipmentCatalog    EquipmentCatalog? @relation(fields: [equipmentCatalogId], references: [id])
+  genericEquipment    GenericEquipment? @relation(fields: [genericEquipmentId], references: [id])
   job                 Job               @relation(fields: [jobId], references: [id], onDelete: Cascade)
   parent              PullsheetItem?    @relation("PullsheetItemHierarchy", fields: [parentId], references: [id], onDelete: Cascade)
   children            PullsheetItem[]   @relation("PullsheetItemHierarchy")
@@ -56,6 +70,7 @@ model PullsheetItem {
 
   @@index([jobId])
   @@index([equipmentCatalogId])
+  @@index([genericEquipmentId])
   @@index([rackDrawingId])
   @@index([flexSection])
   @@index([parentId])

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,45 @@
+import { prisma } from '../src/config/prisma.js';
+
+const genericEquipmentData = [
+  { name: '6U Vent Door', category: 'Vent Doors', rackUnits: 6 },
+  { name: '4U Vent Door', category: 'Vent Doors', rackUnits: 4 },
+  { name: '3U Vent Door', category: 'Vent Doors', rackUnits: 3 },
+  { name: '2U Vent Door', category: 'Vent Doors', rackUnits: 2 },
+  { name: '3U Vent Blank', category: 'Vent Blanks', rackUnits: 3 },
+  { name: '2U Vent Blank', category: 'Vent Blanks', rackUnits: 2 },
+  { name: '1U Vent Blank', category: 'Vent Blanks', rackUnits: 1 },
+  { name: '3U Blank', category: 'Blanks', rackUnits: 3 },
+  { name: '2U Blank', category: 'Blanks', rackUnits: 2 },
+  { name: '1U Blank', category: 'Blanks', rackUnits: 1 },
+  { name: '2U Drawer', category: 'Drawers', rackUnits: 2 },
+  { name: '3U Drawer', category: 'Drawers', rackUnits: 3 },
+  { name: '4U Drawer', category: 'Drawers', rackUnits: 4 },
+];
+
+async function main() {
+  console.log('Seeding generic equipment...');
+
+  for (const item of genericEquipmentData) {
+    await prisma.genericEquipment.upsert({
+      where: { name: item.name },
+      update: {},
+      create: {
+        name: item.name,
+        category: item.category,
+        rackUnits: item.rackUnits,
+        isActive: true,
+      },
+    });
+  }
+
+  console.log('Seed complete!');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import jobRoutes from './routes/jobRoutes.js';
 import equipmentRoutes from './routes/equipmentRoutes.js';
+import genericEquipmentRoutes from './routes/genericEquipmentRoutes.js';
 import placedEquipmentRoutes from './routes/placedEquipmentRoutes.js';
 import rackDrawingRoutes from './routes/rackDrawingRoutes.js';
 import pullsheetRoutes from './routes/pullsheetRoutes.js';
@@ -16,6 +17,7 @@ app.use(express.json());
 // Routes at the top get checked first
 app.use('/api', pullsheetRoutes);
 app.use('/api', equipmentRoutes);
+app.use('/api', genericEquipmentRoutes);
 app.use('/api', placedEquipmentRoutes);
 app.use('/api', jobRoutes);
 app.use('/api', rackDrawingRoutes);

--- a/src/controllers/genericEquipmentController.ts
+++ b/src/controllers/genericEquipmentController.ts
@@ -1,0 +1,46 @@
+import { type Request, type Response } from 'express';
+import { prisma } from '../config/prisma.js';
+
+export const getGenericEquipment = async (req: Request, res: Response) => {
+  try {
+    const equipment = await prisma.genericEquipment.findMany({
+      where: { isActive: true },
+      orderBy: [{ category: 'asc' }, { name: 'asc' }],
+    });
+    res.json(equipment);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch generic equipment' });
+  }
+};
+
+export const createGenericEquipment = async (req: Request, res: Response) => {
+  try {
+    const { name, displayName, category, rackUnits } = req.body;
+
+    // Validate required fields
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      return res.status(400).json({ error: 'name is required and must be a non-empty string' });
+    }
+
+    if (!category || typeof category !== 'string' || !category.trim()) {
+      return res.status(400).json({ error: 'category is required and must be a non-empty string' });
+    }
+
+    if (!Number.isInteger(rackUnits) || rackUnits <= 0) {
+      return res.status(400).json({ error: 'rackUnits is required and must be a positive integer' });
+    }
+
+    const equipment = await prisma.genericEquipment.create({
+      data: {
+        name: name.trim(),
+        displayName: displayName && typeof displayName === 'string' ? displayName.trim() : null,
+        category: category.trim(),
+        rackUnits,
+      },
+    });
+
+    res.status(201).json(equipment);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to create generic equipment' });
+  }
+};

--- a/src/controllers/jobController.ts
+++ b/src/controllers/jobController.ts
@@ -11,6 +11,32 @@ export const getJobs = async (req: Request, res: Response) => {
   }
 }
 
+// Get a specific job by ID
+export const getJob = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const jobId = Number(id);
+
+    if (!Number.isInteger(jobId)) {
+      res.status(400).json({ error: 'Invalid job ID' });
+      return;
+    }
+
+    const job = await prisma.job.findUnique({
+      where: { id: jobId },
+    });
+
+    if (!job) {
+      res.status(404).json({ error: 'Job not found' });
+      return;
+    }
+
+    res.status(200).json(job);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch job' });
+  }
+}
+
 // Create job
 export const createJob = async (req: Request, res: Response) => {
   try {

--- a/src/controllers/placedEquipmentController.ts
+++ b/src/controllers/placedEquipmentController.ts
@@ -86,3 +86,95 @@ export const updateEquipmentName = async (req: Request, res: Response) => {
     res.status(500).json({ error: 'Failed to update equipment name' });
   }
 }
+
+export const getUnplacedItems = async (req: Request, res: Response) => {
+  try {
+    const { jobId } = req.params;
+    const id = Number(jobId);
+
+    if (!Number.isInteger(id)) {
+      res.status(400).json({ error: 'Invalid job ID' });
+      return;
+    }
+
+    const unplacedItems = await prisma.pullsheetItem.findMany({
+      where: {
+        jobId: id,
+        rackDrawingId: null,
+      },
+    });
+
+    res.status(200).json(unplacedItems);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to fetch unplaced items' });
+  }
+}
+
+export const placeGenericEquipment = async (req: Request, res: Response) => {
+  try {
+    const { jobId } = req.params;
+    const jobIdNum = Number(jobId);
+
+    if (!Number.isInteger(jobIdNum)) {
+      return res.status(400).json({ error: 'Invalid job ID' });
+    }
+
+    const { genericEquipmentId, rackDrawingId, quantity, startPosition, side } = req.body;
+
+    // Validate genericEquipmentId
+    if (!Number.isInteger(genericEquipmentId) || genericEquipmentId <= 0) {
+      return res.status(400).json({ error: 'genericEquipmentId is required and must be a positive integer' });
+    }
+
+    // Validate rackDrawingId
+    if (!Number.isInteger(rackDrawingId) || rackDrawingId <= 0) {
+      return res.status(400).json({ error: 'rackDrawingId is required and must be a positive integer' });
+    }
+
+    // Validate quantity
+    if (!Number.isInteger(quantity) || quantity <= 0) {
+      return res.status(400).json({ error: 'quantity is required and must be a positive integer' });
+    }
+
+    // Validate startPosition
+    if (!Number.isInteger(startPosition) || startPosition < 0) {
+      return res.status(400).json({ error: 'startPosition is required and must be a non-negative integer' });
+    }
+
+    // Validate side
+    const validSides = ['FRONT', 'BACK', 'FRONT_LEFT', 'FRONT_RIGHT', 'BACK_LEFT', 'BACK_RIGHT'];
+    if (!side || !validSides.includes(side)) {
+      return res.status(400).json({ error: 'side is required and must be a valid value' });
+    }
+
+    // Look up GenericEquipment
+    const genericEquipment = await prisma.genericEquipment.findUnique({
+      where: { id: genericEquipmentId },
+    });
+
+    if (!genericEquipment) {
+      return res.status(404).json({ error: 'Generic equipment not found' });
+    }
+
+    // Create PullsheetItem with snapshot of generic equipment data
+    const pullsheetItem = await prisma.pullsheetItem.create({
+      data: {
+        jobId: jobIdNum,
+        genericEquipmentId,
+        name: genericEquipment.name,
+        rackUnits: genericEquipment.rackUnits,
+        quantity,
+        rackDrawingId,
+        startPosition,
+        side,
+        isFromPullsheet: false,
+        flexResourceId: '',
+        flexSection: 'Generic',
+      },
+    });
+
+    res.status(201).json(pullsheetItem);
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to place generic equipment' });
+  }
+}

--- a/src/routes/genericEquipmentRoutes.ts
+++ b/src/routes/genericEquipmentRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { getGenericEquipment, createGenericEquipment } from '../controllers/genericEquipmentController.js';
+
+const router = Router();
+
+router.get('/generic-equipment', getGenericEquipment);
+router.post('/generic-equipment', createGenericEquipment);
+
+export default router;

--- a/src/routes/jobRoutes.ts
+++ b/src/routes/jobRoutes.ts
@@ -1,8 +1,12 @@
 import { Router } from 'express';
-import { getJobs } from '../controllers/jobController.js';
+import { getJobs, getJob, createJob, editJob, deleteJob } from '../controllers/jobController.js';
 
 const router = Router();
 
 router.get('/jobs', getJobs);
+router.post('/jobs', createJob);
+router.get('/jobs/:id', getJob);
+router.patch('/jobs/:id', editJob);
+router.delete('/jobs/:id', deleteJob);
 
 export default router;

--- a/src/routes/pullsheetRoutes.ts
+++ b/src/routes/pullsheetRoutes.ts
@@ -1,7 +1,11 @@
 import { Router } from 'express';
 import { importPullsheet } from '../controllers/pullsheetController.js';
+import { getUnplacedItems, placeGenericEquipment } from '../controllers/placedEquipmentController.js';
+
 const router = Router();
 
 router.post('/pullsheet/import', importPullsheet);
+router.get('/jobs/:jobId/pullsheet-items/unplaced', getUnplacedItems);
+router.post('/jobs/:jobId/pullsheet-items/place-generic', placeGenericEquipment);
 
 export default router;


### PR DESCRIPTION
## Summary

This PR adds support for generic equipment (blanks, vent doors, vent blanks, drawers) that can be placed in rack drawings alongside catalog equipment. Generic equipment provides a flexible way to represent common rack components that don't need full catalog integration.

## Key Features

### Database Schema
- **New GenericEquipment model** (`prisma/schema.prisma:33-42`)
  - Fields: `name` (unique), `displayName`, `category`, `rackUnits`, `isActive`
  - Indexed relationship with PullsheetItem via `genericEquipmentId`
- **Updated PullsheetItem model** (`prisma/schema.prisma:45`)
  - Added optional `genericEquipmentId` foreign key
  - Can now reference either catalog equipment OR generic equipment

### API Endpoints

**Generic Equipment Management:**
- `GET /api/generic-equipment` - Fetch all active generic equipment, ordered by category and name
- `POST /api/generic-equipment` - Create new generic equipment with validation

**Placement Operations:**
- `GET /api/jobs/:jobId/pullsheet-items/unplaced` - Get all unplaced items for a job
- `POST /api/jobs/:jobId/pullsheet-items/place-generic` - Place generic equipment in rack drawings

**Job Operations:**
- `GET /api/jobs/:id` - Get a specific job by ID

### Seeding
- Added `prisma/seed.ts` with 13 pre-configured generic equipment items:
  - Vent Doors: 6U, 4U, 3U, 2U
  - Vent Blanks: 3U, 2U, 1U
  - Blanks: 3U, 2U, 1U
  - Drawers: 2U, 3U, 4U
- Run with: `npm run db:seed`

### Input Validation
All endpoints follow project validation standards:
- Normalize strings with `.trim()` before validation
- Type checking with `Number.isInteger()` for IDs
- 400 status for client errors, 500 for server errors
- Proper edge case handling (empty strings, whitespace, non-numeric IDs)

### Bug Fix
- Fixed pullsheet import to handle null `flexResourceId` cases (`src/controllers/pullsheetController.ts:106`)

## Database Migrations
- `20260301033804_add_generic_equipment` - Adds GenericEquipment table and relationship
- `20260301034015_add_generic_equipment_unique_name` - Adds unique constraint on name field

## Files Changed
- **Models:** `prisma/schema.prisma`
- **Controllers:** `genericEquipmentController.ts`, `placedEquipmentController.ts`, `jobController.ts`, `pullsheetController.ts`
- **Routes:** `genericEquipmentRoutes.ts`, `jobRoutes.ts`, `pullsheetRoutes.ts`
- **Config:** `app.ts`, `package.json`, `prisma.config.ts`
- **Seeding:** `prisma/seed.ts`
- **Docs:** `CLAUDE.md`

## Testing Considerations
- Test generic equipment CRUD operations
- Test placement of generic equipment with various rack positions and sides
- Test unplaced items endpoint with different job states
- Verify seed data loads correctly
- Ensure proper validation for all input fields
- Test edge cases: duplicate names, invalid rack units, null/undefined values

## Migration Steps
1. Run migrations: `npm run migrate`
2. Seed generic equipment: `npm run db:seed`
3. Verify seeded data in database

---

Closes #[issue-number] (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generic equipment management: list and create generic equipment items
  * Job management: create, retrieve, update, and delete individual jobs
  * Equipment placement: view unplaced items and place generic equipment on racks

* **Chores**
  * Added database seeding functionality for initial equipment data
  * Updated development workflow scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->